### PR TITLE
Add PHPUnit tests for StreamStorage and CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,19 @@ jobs:
           tools: composer:v2, cs2pr, phpcs:^3.13
 
       - name: Run phpcs
-        run: phpcs -ps --standard=phpcs.xml
+        id: phpcs
+        run: |
+          phpcs -ps --standard=phpcs.xml --report=full --report-file=phpcs-report.txt
+        continue-on-error: true
+
+      - name: Upload phpcs report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phpcs-report
+          path: phpcs-report.txt
+          if-no-files-found: ignore
+
+      - name: Fail if phpcs reported violations
+        if: steps.phpcs.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [master, master56]
+  pull_request:
+    branches: [master, master56]
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['5.6']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, json, curl, pdo, sockets
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate composer.json
+        run: composer validate --no-check-publish
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache composer
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ matrix.php }}-${{ hashFiles('composer.json') }}
+          restore-keys: composer-${{ matrix.php }}-
+
+      - name: Install dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --colors=always
+
+  cs:
+    name: Code style (phpcs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, json
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist
+
+      - name: Run phpcs
+        run: composer cs-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '5.6'
           extensions: mbstring, json
           coverage: none
           tools: composer:v2, phpcs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           php-version: '7.4'
           extensions: mbstring, json
           coverage: none
-          tools: composer:v2, cs2pr, phpcs:^3.13
+          tools: composer:v2, phpcs
 
       - name: Run phpcs
         id: phpcs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
           restore-keys: composer-${{ matrix.php }}-
 
       - name: Install dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist
+        run: |
+          composer remove --dev --no-update vimeo/psalm || true
+          composer update --no-progress --no-interaction --prefer-dist --ignore-platform-reqs
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit --colors=always
@@ -61,7 +63,9 @@ jobs:
           tools: composer:v2
 
       - name: Install dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist
+        run: |
+          composer remove --dev --no-update vimeo/psalm || true
+          composer update --no-progress --no-interaction --prefer-dist
 
       - name: Run phpcs
         run: composer cs-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           php-version: '5.6'
           extensions: mbstring, json
           coverage: none
-          tools: composer:v2, phpcs
+          tools: composer:v2, phpcs:3.7.2
 
       - name: Run phpcs
         id: phpcs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,7 @@ jobs:
           php-version: '7.4'
           extensions: mbstring, json
           coverage: none
-          tools: composer:v2
-
-      - name: Install dependencies
-        run: |
-          composer remove --dev --no-update vimeo/psalm || true
-          composer update --no-progress --no-interaction --prefer-dist
+          tools: composer:v2, cs2pr, phpcs:^3.13
 
       - name: Run phpcs
-        run: composer cs-check
+        run: phpcs -ps --standard=phpcs.xml

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ composer.phar
 composer.lock
 /vendor/
 .phpcs-cache
+.phpunit.result.cache
+/.claude/

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,6 @@ cs-check:
 
 psalm:
 	$(docker) vendor/bin/psalm
+
+test:
+	$(docker) vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,17 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.13",
-    "vimeo/psalm": "1.1.9"
+    "vimeo/psalm": "1.1.9",
+    "phpunit/phpunit": "^5.7"
   },
   "autoload": {
     "psr-4": {
         "Xakki\\PhpErrorCatcher\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+        "Xakki\\PhpErrorCatcher\\Tests\\": "tests/"
     }
   },
   "config": {
@@ -42,6 +48,7 @@
   "scripts": {
     "cs-check": "XDEBUG_MODE=off phpcs -ps",
     "cs-fix": "XDEBUG_MODE=off phpcbf -p",
-    "psalm": "psalm"
+    "psalm": "psalm",
+    "test": "phpunit"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         verbose="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/PhpErrorCatcher.php
+++ b/src/PhpErrorCatcher.php
@@ -624,8 +624,9 @@ class PhpErrorCatcher implements \Psr\Log\LoggerInterface
 
     public static function isAjax()
     {
-        if (!empty($_SERVER['is_json']))
+        if (!empty($_SERVER['is_json'])) {
             return true;
+        }
         if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest') {
             return true;
         }
@@ -1402,7 +1403,7 @@ class PhpErrorCatcher implements \Psr\Log\LoggerInterface
         if (!$this->debugMode && $level === self::LEVEL_DEBUG) {
             return;
         }
-        foreach($context as $k => &$v) {
+        foreach ($context as $k => &$v) {
             if (!is_string($k)) {
                 $context[self::FIELD_TAG] = $v;
                 unset($context[$k]);
@@ -1479,11 +1480,9 @@ class PhpErrorCatcher implements \Psr\Log\LoggerInterface
         if (isset($context[self::FIELD_TRICE])) {
             if (is_string($context[self::FIELD_TRICE])) {
                 $logData->trace = $context[self::FIELD_TRICE];
-            }
-            elseif (is_array($context[self::FIELD_TRICE])) {
+            } elseif (is_array($context[self::FIELD_TRICE])) {
                 $logData->trace = $this->renderDebugTrace($context[self::FIELD_TRICE]);
-            }
-            else {
+            } else {
                 $logData->trace = json_encode($context[self::FIELD_TRICE]);
             }
         } elseif (isset($this->logTraceByLevel[$level]) && empty($context[self::FIELD_NO_TRICE])) {

--- a/src/storage/FileStorage.php
+++ b/src/storage/FileStorage.php
@@ -51,7 +51,7 @@ class FileStorage extends BaseStorage
     public function __construct(PhpErrorCatcher $owner, $config = [])
     {
         parent::__construct($owner, $config);
-        $this->tmpFile = $this->getFullLogDir().  '_' .uniqid('tmp_', true) . rand(1,1000000) . '_' . (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '') ;
+        $this->tmpFile = $this->getFullLogDir() . '_' . uniqid('tmp_', true) . rand(1, 1000000) . '_' . (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '');
     }
 
     /**
@@ -108,8 +108,6 @@ class FileStorage extends BaseStorage
             $this->isEmptyTmpFile = false;
             $this->lastTimeSave = time();
         }
-
-
     }
 
     /**
@@ -175,7 +173,9 @@ class FileStorage extends BaseStorage
         $handle = fopen($this->tmpFile, "r");
         if ($handle) {
             while (($logData = fgets($handle)) !== false) {
-                if (!$logData) continue;
+                if (!$logData) {
+                    continue;
+                }
                 /** @var LogData $logData */
                 $logData = json_decode($logData);
                 if (isset($this->logKeys[$logData->logKey]) && $this->logKeys[$logData->logKey] > 1) {

--- a/tests/StreamStorageTest.php
+++ b/tests/StreamStorageTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Xakki\PhpErrorCatcher\Tests;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Xakki\PhpErrorCatcher\PhpErrorCatcher;
+use Xakki\PhpErrorCatcher\dto\LogData;
+use Xakki\PhpErrorCatcher\storage\StreamStorage;
+
+class StreamStorageTest extends TestCase
+{
+    /** @var string */
+    private $tmpFile;
+
+    /** @var PhpErrorCatcher */
+    private $owner;
+
+    public function setUp()
+    {
+        $this->tmpFile = tempnam(sys_get_temp_dir(), 'pec-stream-');
+
+        $ref = new ReflectionClass('Xakki\\PhpErrorCatcher\\PhpErrorCatcher');
+        $this->owner = $ref->newInstanceWithoutConstructor();
+
+        $prop = $ref->getProperty('_obj');
+        $prop->setAccessible(true);
+        $prop->setValue(null, $this->owner);
+    }
+
+    public function tearDown()
+    {
+        if ($this->tmpFile && file_exists($this->tmpFile)) {
+            unlink($this->tmpFile);
+        }
+        $ref = new ReflectionClass('Xakki\\PhpErrorCatcher\\PhpErrorCatcher');
+        $prop = $ref->getProperty('_obj');
+        $prop->setAccessible(true);
+        $prop->setValue(null, null);
+    }
+
+    /**
+     * @param array $config
+     * @return StreamStorage
+     */
+    private function makeStorage(array $config = array())
+    {
+        $config = array_merge(array('stream' => $this->tmpFile), $config);
+        return new StreamStorage($this->owner, $config);
+    }
+
+    /**
+     * @param int $levelInt
+     * @param string $level
+     * @param string $message
+     * @return LogData
+     */
+    private function makeLogData($levelInt = LOG_ERR, $level = 'error', $message = 'boom')
+    {
+        return LogData::init(array(
+            'logKey' => 'k1',
+            'message' => $message,
+            'level' => $level,
+            'levelInt' => $levelInt,
+            'type' => 'logger',
+            'trace' => '#0 /app/x.php(10)',
+            'file' => '/app/x.php:10',
+            'fields' => array('tag' => 'payments', 'extra_field' => 'v'),
+            'microtime' => 1714210000.123456,
+            'count' => 1,
+        ));
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function readLines()
+    {
+        $content = file_get_contents($this->tmpFile);
+        if ($content === '' || $content === false) {
+            return array();
+        }
+        $out = array();
+        foreach (explode("\n", trim($content, "\n")) as $line) {
+            if ($line === '') {
+                continue;
+            }
+            $out[] = json_decode($line, true);
+        }
+        return $out;
+    }
+
+    public function testWriteProducesMonologCompatibleJson()
+    {
+        $storage = $this->makeStorage();
+        $storage->write($this->makeLogData());
+        unset($storage);
+
+        $records = $this->readLines();
+        $this->assertCount(1, $records);
+        $rec = $records[0];
+
+        $this->assertSame(
+            array('message', 'context', 'level', 'level_name', 'channel', 'datetime', 'extra'),
+            array_keys($rec)
+        );
+        $this->assertSame('boom', $rec['message']);
+        $this->assertSame(400, $rec['level']);
+        $this->assertSame('ERROR', $rec['level_name']);
+        $this->assertSame('php', $rec['channel']);
+        $this->assertSame('payments', $rec['context']['tag']);
+        $this->assertSame('v', $rec['context']['extra_field']);
+        $this->assertSame('logger', $rec['context']['log_type']);
+        $this->assertSame('/app/x.php:10', $rec['context']['file']);
+        $this->assertSame('k1', $rec['context']['log_key']);
+        $this->assertArrayHasKey('trace', $rec['context']);
+        $this->assertArrayHasKey('hostname', $rec['extra']);
+        $this->assertArrayHasKey('pid', $rec['extra']);
+        $this->assertSame(PhpErrorCatcher::VERSION, $rec['extra']['ver']);
+    }
+
+    public function testDatetimeIsIso8601WithMicroseconds()
+    {
+        $storage = $this->makeStorage();
+        $storage->write($this->makeLogData());
+        unset($storage);
+
+        $records = $this->readLines();
+        $this->assertCount(1, $records);
+        $this->assertRegExp(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}[+\-]\d{2}:\d{2}$/',
+            $records[0]['datetime']
+        );
+    }
+
+    /**
+     * @return array<string, array<int, int|int|string>>
+     */
+    public function levelMappingProvider()
+    {
+        return array(
+            'debug'    => array(LOG_DEBUG,   100, 'DEBUG'),
+            'info'     => array(LOG_INFO,    200, 'INFO'),
+            'notice'   => array(LOG_NOTICE,  250, 'NOTICE'),
+            'warning'  => array(LOG_WARNING, 300, 'WARNING'),
+            'error'    => array(LOG_ERR,     400, 'ERROR'),
+            'critical' => array(LOG_CRIT,    500, 'CRITICAL'),
+            'alert'    => array(LOG_ALERT,   550, 'ALERT'),
+            'emerg'    => array(LOG_EMERG,   600, 'EMERGENCY'),
+        );
+    }
+
+    /**
+     * @dataProvider levelMappingProvider
+     */
+    public function testSyslogToMonologLevelMapping($syslog, $expectedLevel, $expectedName)
+    {
+        $storage = $this->makeStorage();
+        $storage->write($this->makeLogData($syslog, 'x'));
+        unset($storage);
+
+        $records = $this->readLines();
+        $this->assertSame($expectedLevel, $records[0]['level']);
+        $this->assertSame($expectedName, $records[0]['level_name']);
+    }
+
+    public function testMinLevelIntFiltersOutVerbose()
+    {
+        $storage = $this->makeStorage(array('minLevelInt' => LOG_WARNING));
+        $storage->write($this->makeLogData(LOG_DEBUG, 'debug'));
+        $storage->write($this->makeLogData(LOG_ERR, 'error'));
+        unset($storage);
+
+        $records = $this->readLines();
+        $this->assertCount(1, $records);
+        $this->assertSame(400, $records[0]['level']);
+    }
+
+    public function testExtraFieldsAreMergedIntoExtra()
+    {
+        $storage = $this->makeStorage(array(
+            'channel' => 'app',
+            'extraFields' => array('service' => 'my-app', 'env' => 'prod'),
+        ));
+        $storage->write($this->makeLogData());
+        unset($storage);
+
+        $records = $this->readLines();
+        $this->assertSame('app', $records[0]['channel']);
+        $this->assertSame('my-app', $records[0]['extra']['service']);
+        $this->assertSame('prod', $records[0]['extra']['env']);
+    }
+
+    public function testIncludeStacktracesFalseStripsTrace()
+    {
+        $storage = $this->makeStorage(array('includeStacktraces' => false));
+        $storage->write($this->makeLogData());
+        unset($storage);
+
+        $records = $this->readLines();
+        $this->assertArrayNotHasKey('trace', $records[0]['context']);
+    }
+
+    public function testEachLineEndsWithNewline()
+    {
+        $storage = $this->makeStorage();
+        $storage->write($this->makeLogData());
+        $storage->write($this->makeLogData(LOG_INFO, 'info', 'second'));
+        unset($storage);
+
+        $content = file_get_contents($this->tmpFile);
+        $this->assertStringEndsWith("\n", $content);
+        $this->assertSame(2, substr_count($content, "\n"));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+// PHPUnit 5.7 + PHP 5.6 bootstrap.
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+} else {
+    spl_autoload_register(function ($class) {
+        $prefix = 'Xakki\\PhpErrorCatcher\\';
+        if (strpos($class, $prefix) !== 0) {
+            return;
+        }
+        $relative = substr($class, strlen($prefix));
+        $path = __DIR__ . '/../src/' . str_replace('\\', '/', $relative) . '.php';
+        if (file_exists($path)) {
+            require_once $path;
+        }
+    });
+}


### PR DESCRIPTION
- tests/StreamStorageTest.php — Monolog-format JSON validation, level mapping, splitByLevel, minLevelInt filter, datetime ISO 8601 with microseconds.
- phpunit.xml.dist + tests/bootstrap.php (PHPUnit 5.7 for PHP 5.6).
- composer.json: add phpunit/phpunit ^5.7 in require-dev, autoload-dev for tests, scripts.test.
- Makefile: add test target via docker.
- .gitignore: ignore .phpunit.result.cache and local .claude/ dir.
- .github/workflows/ci.yml: PHPUnit on PHP 5.6 + phpcs (PSR-12) on PHP 7.4.